### PR TITLE
[Chore #161960628] Make ipfs_path OPTIONAL

### DIFF
--- a/src/witness.cpp
+++ b/src/witness.cpp
@@ -1,6 +1,6 @@
 #include "witness.hpp"
 
-ACTION witness::claim(const eosio::name &user, const uint64_t &timestamp, const std::string category, std::string content, const std::string ipfs_path, const std::vector<eosio::name> &witnesses)
+ACTION witness::claim(const eosio::name &user, const uint64_t &timestamp, const std::string category, std::string content, std::string ipfs_path, const std::vector<eosio::name> &witnesses)
 {
     require_auth(user);
     // Constrain content length to 280 chars (Tweet length)

--- a/src/witness.hpp
+++ b/src/witness.hpp
@@ -9,7 +9,7 @@ CONTRACT witness : public eosio::contract
   public:
     witness(eosio::name self, eosio::name code, eosio::datastream<const char *> stream) : contract(self, code, stream), _claims(self, self.value), _attestations(self, self.value) {}
 
-    ACTION claim(const eosio::name &user, const uint64_t &timestamp, const std::string category, std::string content, const std::string ipfs_path, const std::vector<eosio::name> &witnesses);
+    ACTION claim(const eosio::name &user, const uint64_t &timestamp, const std::string category, std::string content, std::string ipfs_path, const std::vector<eosio::name> &witnesses);
 
     ACTION attest(const uint64_t &timestamp, const eosio::name &user, const eosio::name &reviewer, const std::string &review, std::string ipfs_path);
 


### PR DESCRIPTION
Make the mandatory field `ipfs_path` optional.